### PR TITLE
Return text data as UTF-8

### DIFF
--- a/nginx.vh.default.conf
+++ b/nginx.vh.default.conf
@@ -1,4 +1,5 @@
 server {
+    charset      utf-8;
     listen       80;
     server_name  localhost;
     location / {


### PR DESCRIPTION
Add `charset utf-8` to the default nginx configuration, so that static HTML etc is sent with a Content-Type of UTF-8. That allows non-ASCII alphabets to be transmitted without needing to provide a custom nginx configuration.